### PR TITLE
Flush config file to avoid losing data

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ async fn init_file_if_not_exists(
 
         if let Some(text) = text {
             file.write_all(text).await?;
+            file.flush().await?;
         }
     }
     Ok(())


### PR DESCRIPTION
For some reason not flushing the config file will sometime cause the
write to not complete resulting in an empty config file. This behaviour
seems like a bug, possible in async-std, and should be investigated
furtherer.