### PR TITLE
Assume gemini:// for schemeless URLs in the omnibar

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -360,7 +360,13 @@ impl Window {
     }
     fn open_omni(&self, v: &str) {
         let url = Url::parse(v)
-            .or_else(|_| Url::parse(&format!("gemini://geminispace.info/search?{}", v)));
+            .or_else(|_| {
+                if v.contains(".") && v.split(".").all(|s| s.chars().all(char::is_alphanumeric)) {
+                    Url::parse(&format!("gemini://{}", v))
+                } else {
+                    Url::parse(&format!("gemini://geminispace.info/search?{}", v))
+                }
+            });
         match url {
             Ok(url) => self.current_tab().spawn_open_url(url),
             Err(e) => error!("Failed to open from omni bar"),


### PR DESCRIPTION
This patch allows URLs entered into the omnibar without a scheme to be resolved as `gemini://`, similar to how modern web browsers don't require you to enter `http[s]://`.

Currently, this somewhat arbitrarily requires schemeless URLs to contain a period--otherwise, every ASCII string without whitespace would be considered a valid domain and single-term search queries would be broken.