### PR TITLE
Don't show url_status_box on start

### DIFF
--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -100,6 +100,7 @@ template GeopardWindow: Adw.ApplicationWindow {
         orientation: vertical;
         valign: end;
         Gtk.Box url_status_box {
+          visible: false;
           styles ["background"]
           Gtk.Label url_status {
             xalign: 0.0;


### PR DESCRIPTION
This isn't a big issue on desktop. But on a touch screen, handle_motion is never triggered and an empty url_status_box is always visible.

![20230213_20h11m11s_grim](https://user-images.githubusercontent.com/31200881/218454854-ff781633-e81d-483b-b6ca-97fe44fafb22.png)
