### PR TITLE
fix: Typo in build file

### DIFF
--- a/build-aux/com.ranfdev.Geopard.Devel.json
+++ b/build-aux/com.ranfdev.Geopard.Devel.json
@@ -22,7 +22,7 @@
     "build-options" : {
         "append-path" : "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm16/bin",
         "build-args" : [
-            "--share=network",
+            "--share=network"
         ],
         "env" : {
             "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER" : "clang",


### PR DESCRIPTION
Apparently this comma prevented GNOME Builder from detecting this build configuration