### PR TITLE
A Pack of Improvements

### DIFF
--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -6,7 +6,7 @@ install_data(
 
 symbolic_dir = join_paths('hicolor', 'symbolic', 'apps')
 install_data(
-  join_paths(symbolic_dir, 'com.ranfdev.Geopard-symbolic.svg'.format(application_id)),
+  join_paths(symbolic_dir, 'com.ranfdev.Geopard-symbolic.svg'),
   install_dir: join_paths(get_option('datadir'), 'icons', symbolic_dir),
   rename: '@0@-symbolic.svg'.format(application_id)
 )

--- a/data/resources/ui/download_page.blp
+++ b/data/resources/ui/download_page.blp
@@ -2,49 +2,66 @@ using Gtk 4.0;
 using Adw 1;
 
 template $Download: Gtk.Box {
-  margin-top: 8;
-  margin-bottom: 8;
-  margin-start: 8;
-  margin-end: 8;
+  margin-top: 24;
+  margin-bottom: 24;
+  margin-start: 24;
+  margin-end: 24;
   orientation: vertical;
   valign: center;
-  Gtk.Box {
-    orientation: horizontal;
-    spacing: 16;
-    Gtk.Image {
-      icon-name: "folder-download-symbolic";
-      pixel-size: 48;
-      valign: center;
-    }
-    Gtk.Box {
+  hexpand: true;
+  vexpand: true;
+
+  Adw.Clamp {
+    maximum-size: 800;
+
+    child: Gtk.Box {
       orientation: vertical;
-      valign: center;
-      margin-top: 8;
-      margin-bottom: 8;
-      Gtk.Label label {
-        styles ["heading"]
-        label: "Text";
-        xalign: 0.0;
-        wrap: true;
+
+      Gtk.Box {
+        orientation: horizontal;
+        spacing: 16;
+
+        Gtk.Image {
+          icon-name: "folder-download-symbolic";
+          pixel-size: 48;
+          valign: center;
+        }
+
+        Gtk.Box {
+          orientation: vertical;
+          valign: center;
+          margin-top: 8;
+          margin-bottom: 8;
+
+          Gtk.Label label {
+            styles ["heading"]
+            label: "Text";
+            xalign: 0.0;
+            wrap: true;
+          }
+
+          Gtk.Label label_downloaded {
+            styles ["numeric"]
+            label: "0KB";
+            xalign: 0.0;
+          }
+
+          Gtk.ProgressBar progress_bar {
+            margin-top: 8;
+            pulse-step: 0.1;
+            hexpand: true;
+          }
+        }
       }
-      Gtk.Label label_downloaded {
-        styles ["numeric"]
-        label: "0KB";
-        xalign: 0.0;
-      }
-      Gtk.ProgressBar progress_bar {
+
+      Gtk.Button open_btn {
+        styles ["pill"]
+        label: "Stream (alpha)";
         margin-top: 8;
-        pulse-step: 0.1;
-        hexpand: true;
+        margin-bottom: 8;
+        opacity: 0;
+        halign: center;
       }
-    }
-  }
-  Gtk.Button open_btn {
-    styles ["pill"]
-    label: "Stream (alpha)";
-    margin-top: 8;
-    margin-bottom: 8;
-    opacity: 0;
-    halign: center;
+    };
   }
 }

--- a/data/resources/ui/input_page.blp
+++ b/data/resources/ui/input_page.blp
@@ -2,25 +2,38 @@ using Gtk 4.0;
 using Adw 1;
 
 template $Input: Gtk.Box {
-  margin-top: 8;
-  margin-bottom: 8;
-  margin-start: 8;
-  margin-end: 8;
+  margin-top: 24;
+  margin-bottom: 24;
+  margin-start: 24;
+  margin-end: 24;
   orientation: vertical;
   valign: center;
-  Gtk.Label label {
-    styles ["title-4"]
-    label: "Text";
-    xalign: 0.0;
-    margin-top: 8;
-    margin-bottom: 8;
-    margin-start: 8;
-    margin-end: 8;
-    wrap: true;
-  }
-  Gtk.Entry entry {
-    margin-bottom: 8;
-    margin-start: 8;
-    margin-end: 8;
+  hexpand: true;
+  vexpand: true;
+
+  Adw.Clamp {
+    maximum-size: 800;
+
+    child: Gtk.Box {
+      orientation: vertical;
+
+      Gtk.Label label {
+        styles ["title-4"]
+        label: "Text";
+        xalign: 0.0;
+        margin-top: 8;
+        margin-bottom: 8;
+        margin-start: 8;
+        margin-end: 8;
+        wrap: true;
+        halign: center;
+      }
+
+      Gtk.Entry entry {
+        margin-bottom: 8;
+        margin-start: 8;
+        margin-end: 8;
+      }
+    };
   }
 }

--- a/data/resources/ui/tab.blp
+++ b/data/resources/ui/tab.blp
@@ -5,11 +5,11 @@ template $Tab: Adw.Bin {
   Gtk.Stack stack {
     Gtk.ScrolledWindow scroll_win {
       vexpand: true;
+
       Adw.ClampScrollable clamp {
         halign: center;
         maximum-size: 768;
         tightening-threshold: 720;
-
       }
     }
   }

--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -79,6 +79,7 @@ template $GeopardWindow: Adw.ApplicationWindow {
                 icon-name: "open-menu";
                 menu-model: primary_menu;
                 tooltip-text: _("Main menu");
+                primary: true;
               }
 
               [end]

--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -15,167 +15,172 @@ template $GeopardWindow: Adw.ApplicationWindow {
         view: tab_view;
         enable-new-tab: true;
 
-        Adw.ToolbarView toolbar_view {
-          reveal-bottom-bars: false;
+        Adw.ToastOverlay toast_overlay {
+          Adw.ToolbarView toolbar_view {
+            reveal-bottom-bars: false;
 
-          [top]
-          Adw.HeaderBar {
-            [start]
-            Gtk.Box previous_box {
-              Gtk.Button previous {
+            [top]
+            Adw.HeaderBar {
+              [start]
+              Gtk.Box previous_box {
+                Gtk.Button previous {
+                  icon-name: "go-previous-symbolic";
+                  action-name: "win.previous";
+                  tooltip-text: _("Go back one page\nRight-click to show history");
+                }
+
+                Gtk.Popover previous_popover {
+                  autohide: true;
+                  has-arrow: false;
+                }
+              }
+
+              [start]
+              Gtk.Box next_box {
+                Gtk.Button next {
+                  icon-name: "go-next-symbolic";
+                  action-name: "win.next";
+                  tooltip-text: _("Go forward one page\nRight-click to show history");
+                }
+
+                Gtk.Popover next_popover {
+                  autohide: true;
+                  has-arrow: false;
+                }
+              }
+
+              [start]
+              Gtk.Button refresh_btn {
+                icon-name: "view-refresh-symbolic";
+                action-name: "win.reload";
+                tooltip-text: _("Reload current page");
+              }
+
+              [start]
+              Gtk.Button tab_new_btn {
+                icon-name: "tab-new-symbolic";
+                action-name: "win.new-tab";
+                tooltip-text: _("Open a new tab");
+              }
+
+              [title]
+              Adw.Clamp {
+                maximum-size: 768;
+                tightening-threshold: 720;
+
+                Gtk.SearchEntry url_bar {
+                  hexpand: true;
+                  placeholder-text: _("Enter Gemini address or search with Geminispace");
+                }
+              }
+
+              [end]
+              Gtk.MenuButton primary_menu_btn {
+                icon-name: "open-menu";
+                menu-model: primary_menu;
+                tooltip-text: _("Main menu");
+              }
+
+              [end]
+              Gtk.Button desktop_tab_overview_btn {
+                icon-name: "view-grid-symbolic";
+                action-name: "overview.open";
+                tooltip-text: _("Open tab overview");
+              }
+            }
+
+            [top]
+            Gtk.Revealer tab_bar_revealer {
+              reveal-child: true;
+              Adw.TabBar tab_bar {
+                view: tab_view;
+              }
+            }
+
+            content: Gtk.Box {
+              orientation: vertical;
+
+              Gtk.Overlay {
+                Adw.TabView tab_view {
+                  vexpand: true;
+                  hexpand: true;
+                }
+
+                [overlay]
+                Gtk.ProgressBar progress_bar {
+                  styles ["osd"]
+                  valign: start;
+                  text: bind template.progress;
+                }
+
+                [overlay]
+                Gtk.Box {
+                  orientation: vertical;
+                  valign: end;
+
+                  Gtk.Box url_status_box {
+                    visible: false;
+                    styles ["background"]
+
+                    Gtk.Label url_status {
+                      xalign: 0.0;
+                      ellipsize: end;
+                      margin-top: 6;
+                      margin-bottom: 6;
+                      margin-start: 6;
+                      margin-end: 6;
+                    }
+                  }
+                }
+              }
+            };
+
+            [bottom]
+            Adw.HeaderBar bottom_bar {
+              show-end-title-buttons: false;
+              show-start-title-buttons: false;
+
+              [start]
+              Gtk.Button {
                 icon-name: "go-previous-symbolic";
                 action-name: "win.previous";
                 tooltip-text: _("Go back one page\nRight-click to show history");
               }
 
-              Gtk.Popover previous_popover {
-                autohide: true;
-                has-arrow: false;
-              }
-            }
-
-            [start]
-            Gtk.Box next_box {
-              Gtk.Button next {
+              [start]
+              Gtk.Button {
                 icon-name: "go-next-symbolic";
                 action-name: "win.next";
                 tooltip-text: _("Go forward one page\nRight-click to show history");
               }
 
-              Gtk.Popover next_popover {
-                autohide: true;
-                has-arrow: false;
-              }
-            }
-
-            [start]
-            Gtk.Button refresh_btn {
-              icon-name: "view-refresh-symbolic";
-              action-name: "win.reload";
-              tooltip-text: _("Reload current page");
-            }
-
-            [start]
-            Gtk.Button tab_new_btn {
-              icon-name: "tab-new-symbolic";
-              action-name: "win.new-tab";
-              tooltip-text: _("Open a new tab");
-            }
-
-            [title]
-            Adw.Clamp {
-              maximum-size: 768;
-              tightening-threshold: 720;
-
-              Gtk.SearchEntry url_bar {
-                hexpand: true;
-                placeholder-text: _("Enter Gemini address or search with Geminispace");
-              }
-            }
-
-            [end]
-            Gtk.MenuButton primary_menu_btn {
-              icon-name: "open-menu";
-              menu-model: primary_menu;
-              tooltip-text: _("Main menu");
-            }
-
-            [end]
-            Gtk.Button desktop_tab_overview_btn {
-              icon-name: "view-grid-symbolic";
-              action-name: "overview.open";
-              tooltip-text: _("Open tab overview");
-            }
-          }
-          [top]
-          Gtk.Revealer tab_bar_revealer {
-            reveal-child: true;
-            Adw.TabBar tab_bar {
-              view: tab_view;
-            }
-          }
-
-          content: Gtk.Box {
-            orientation: vertical;
-            Gtk.Overlay {
-              Adw.TabView tab_view {
-                vexpand: true;
-                hexpand: true;
+              [start]
+              Gtk.Button {
+                icon-name: "view-refresh-symbolic";
+                action-name: "win.reload";
+                tooltip-text: _("Reload current page");
               }
 
-              [overlay]
-              Gtk.ProgressBar progress_bar {
-                styles ["osd"]
-                valign: start;
-                text: bind template.progress;
+              [title]
+              Gtk.Button {
+                icon-name: "system-search-symbolic";
+                action-name: "win.focus-url-bar";
+                tooltip-text: _("Start searching");
               }
 
-              [overlay]
-              Gtk.Box {
-                orientation: vertical;
-                valign: end;
-
-                Gtk.Box url_status_box {
-                  visible: false;
-                  styles ["background"]
-
-                  Gtk.Label url_status {
-                    xalign: 0.0;
-                    ellipsize: end;
-                    margin-top: 6;
-                    margin-bottom: 6;
-                    margin-start: 6;
-                    margin-end: 6;
-                  }
-                }
+              [end]
+              Gtk.MenuButton {
+                icon-name: "open-menu";
+                menu-model: primary_menu;
+                tooltip-text: _("Main menu");
               }
-            }
-          };
-          [bottom]
-          Adw.HeaderBar bottom_bar {
-            show-end-title-buttons: false;
-            show-start-title-buttons: false;
 
-            [start]
-            Gtk.Button {
-              icon-name: "go-previous-symbolic";
-              action-name: "win.previous";
-              tooltip-text: _("Go back one page\nRight-click to show history");
-            }
-
-            [start]
-            Gtk.Button {
-              icon-name: "go-next-symbolic";
-              action-name: "win.next";
-              tooltip-text: _("Go forward one page\nRight-click to show history");
-            }
-
-            [start]
-            Gtk.Button {
-              icon-name: "view-refresh-symbolic";
-              action-name: "win.reload";
-              tooltip-text: _("Reload current page");
-            }
-
-            [title]
-            Gtk.Button {
-              icon-name: "system-search-symbolic";
-              action-name: "win.focus-url-bar";
-              tooltip-text: _("Start searching");
-            }
-
-            [end]
-            Gtk.MenuButton {
-              icon-name: "open-menu";
-              menu-model: primary_menu;
-              tooltip-text: _("Main menu");
-            }
-
-            [end]
-            Gtk.Button {
-              icon-name: "view-grid-symbolic";
-              action-name: "overview.open";
-              tooltip-text: _("Open tab overview");
+              [end]
+              Gtk.Button {
+                icon-name: "view-grid-symbolic";
+                action-name: "overview.open";
+                tooltip-text: _("Open tab overview");
+              }
             }
           }
         }

--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -75,7 +75,7 @@ template $GeopardWindow: Adw.ApplicationWindow {
               }
 
               [end]
-              Gtk.MenuButton primary_menu_btn {
+              Gtk.MenuButton main_menu_button {
                 icon-name: "open-menu";
                 menu-model: primary_menu;
                 tooltip-text: _("Main menu");
@@ -169,13 +169,6 @@ template $GeopardWindow: Adw.ApplicationWindow {
               }
 
               [end]
-              Gtk.MenuButton {
-                icon-name: "open-menu";
-                menu-model: primary_menu;
-                tooltip-text: _("Main menu");
-              }
-
-              [end]
               Gtk.Button {
                 icon-name: "view-grid-symbolic";
                 action-name: "overview.open";
@@ -195,14 +188,12 @@ template $GeopardWindow: Adw.ApplicationWindow {
       next_box.visible: false;
       refresh_btn.visible: false;
       tab_new_btn.visible: false;
-      primary_menu_btn.visible: false;
       desktop_tab_overview_btn.visible: false;
       toolbar_view.reveal-bottom-bars: true;
       tab_bar_revealer.reveal-child: false;
     }
   }
 }
-
 
 menu primary_menu {
   section {

--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -26,7 +26,7 @@ template $GeopardWindow: Adw.ApplicationWindow {
                 Gtk.Button previous {
                   icon-name: "go-previous-symbolic";
                   action-name: "win.previous";
-                  tooltip-text: _("Go back one page\nRight-click to show history");
+                  tooltip-text: _("Go Back\nRight-click to show history");
                 }
 
                 Gtk.Popover previous_popover {
@@ -40,7 +40,7 @@ template $GeopardWindow: Adw.ApplicationWindow {
                 Gtk.Button next {
                   icon-name: "go-next-symbolic";
                   action-name: "win.next";
-                  tooltip-text: _("Go forward one page\nRight-click to show history");
+                  tooltip-text: _("Go Forward\nRight-click to show history");
                 }
 
                 Gtk.Popover next_popover {
@@ -53,14 +53,14 @@ template $GeopardWindow: Adw.ApplicationWindow {
               Gtk.Button refresh_btn {
                 icon-name: "view-refresh-symbolic";
                 action-name: "win.reload";
-                tooltip-text: _("Reload current page");
+                tooltip-text: _("Reload");
               }
 
               [start]
               Gtk.Button tab_new_btn {
                 icon-name: "tab-new-symbolic";
                 action-name: "win.new-tab";
-                tooltip-text: _("Open a new tab");
+                tooltip-text: _("New Tab");
               }
 
               [title]
@@ -78,7 +78,7 @@ template $GeopardWindow: Adw.ApplicationWindow {
               Gtk.MenuButton main_menu_button {
                 icon-name: "open-menu";
                 menu-model: primary_menu;
-                tooltip-text: _("Main menu");
+                tooltip-text: _("Main Menu");
                 primary: true;
               }
 
@@ -86,7 +86,7 @@ template $GeopardWindow: Adw.ApplicationWindow {
               Gtk.Button desktop_tab_overview_btn {
                 icon-name: "view-grid-symbolic";
                 action-name: "overview.open";
-                tooltip-text: _("Open tab overview");
+                tooltip-text: _("View Open Tabs");
               }
             }
 
@@ -145,35 +145,35 @@ template $GeopardWindow: Adw.ApplicationWindow {
               Gtk.Button {
                 icon-name: "go-previous-symbolic";
                 action-name: "win.previous";
-                tooltip-text: _("Go back one page\nRight-click to show history");
+                tooltip-text: _("Go Back\nRight-click to show history");
               }
 
               [start]
               Gtk.Button {
                 icon-name: "go-next-symbolic";
                 action-name: "win.next";
-                tooltip-text: _("Go forward one page\nRight-click to show history");
+                tooltip-text: _("Go Forward\nRight-click to show history");
               }
 
               [start]
               Gtk.Button {
                 icon-name: "view-refresh-symbolic";
                 action-name: "win.reload";
-                tooltip-text: _("Reload current page");
+                tooltip-text: _("Reload");
               }
 
               [title]
               Gtk.Button {
                 icon-name: "system-search-symbolic";
                 action-name: "win.focus-url-bar";
-                tooltip-text: _("Start searching");
+                tooltip-text: _("Start Searching");
               }
 
               [end]
               Gtk.Button {
                 icon-name: "view-grid-symbolic";
                 action-name: "overview.open";
-                tooltip-text: _("Open tab overview");
+                tooltip-text: _("View Open Tabs");
               }
             }
           }
@@ -218,7 +218,7 @@ menu primary_menu {
       action: "win.show-help-overlay";
     }
     item {
-      label: "About";
+      label: "About Geopard";
       action: "win.about";
     }
   }

--- a/gemini/src/client.rs
+++ b/gemini/src/client.rs
@@ -12,7 +12,8 @@ use url::Url;
 use crate::{known_hosts, CertificateError};
 
 const MAX_REDIRECT: u8 = 5;
-const MAX_TIMEOUT: u32 = 10000;
+// Timeout measured in seconds
+const MAX_TIMEOUT_SECONDS: u32 = 10;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProtoError {
@@ -272,7 +273,7 @@ impl Client {
             gio::NetworkAddress::parse_uri(url.as_str(), 1965).map_err(|_| Error::InvalidHost)?;
         let socket = gio::SocketClient::new();
         socket.set_tls(true);
-        socket.set_timeout(MAX_TIMEOUT);
+        socket.set_timeout(MAX_TIMEOUT_SECONDS);
 
         let tls_error = Rc::new(RefCell::new(None));
         let validator = self.validator.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
         .resource_base_path("/com/ranfdev/Geopard/")
         .build();
 
-    println!("{}", config::APP_ID);
+    //println!("{}", config::APP_ID);
 
     let config = futures::executor::block_on(async {
         create_base_files().await.unwrap();
@@ -130,14 +130,8 @@ fn main() {
         }
     });
 
-    application.set_accels_for_action(
-        "win.previous",
-        &["<Alt>Left", "<Alt>KP_Left", "Pointer_DfltBtnPrev"],
-    );
-    application.set_accels_for_action(
-        "win.next",
-        &["<Alt>Right", "<Alt>KP_Right", "Pointer_DfltBtnNext"],
-    );
+    application.set_accels_for_action("win.previous", &["<Alt>Left", "<Alt>KP_Left"]);
+    application.set_accels_for_action("win.next", &["<Alt>Right", "<Alt>KP_Right"]);
     application.set_accels_for_action("win.reload", &["<Ctrl>r", "F5"]);
     application.set_accels_for_action("win.show-bookmarks", &["<Ctrl>b"]);
     application.set_accels_for_action("win.bookmark-current", &["<Ctrl>d"]);

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -3,5 +3,4 @@ mod pages;
 mod tab;
 mod window;
 
-pub use tab::Tab;
 pub use window::Window;

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -71,7 +71,7 @@ pub mod imp {
         #[template_child]
         pub(crate) tab_bar_revealer: TemplateChild<gtk::Revealer>,
         #[template_child]
-        pub(crate) primary_menu_btn: TemplateChild<gtk::MenuButton>,
+        pub(crate) main_menu_button: TemplateChild<gtk::MenuButton>,
         pub(crate) config: RefCell<config::Config>,
         pub(crate) progress_animation: RefCell<Option<adw::SpringAnimation>>,
         pub(crate) binded_tab_properties: RefCell<Vec<glib::Binding>>,
@@ -382,7 +382,9 @@ impl Window {
     fn setup_zoom_popover_item(&self) {
         let imp = self.imp();
 
-        let popover: gtk::PopoverMenu = imp.primary_menu_btn.popover().unwrap().downcast().unwrap();
+        let menu_popover: gtk::PopoverMenu =
+            imp.main_menu_button.popover().unwrap().downcast().unwrap();
+
         let zoom_box = gtk::Box::builder()
             .spacing(12)
             .margin_start(18)
@@ -419,7 +421,7 @@ impl Window {
                 .action_name("win.zoom-in")
                 .build(),
         );
-        popover.add_child(&zoom_box, "zoom");
+        menu_popover.add_child(&zoom_box.clone(), "zoom");
     }
     fn setup_history_button<
         F: for<'a> Fn(

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -421,7 +421,7 @@ impl Window {
                 .action_name("win.zoom-in")
                 .build(),
         );
-        menu_popover.add_child(&zoom_box.clone(), "zoom");
+        menu_popover.add_child(&zoom_box, "zoom");
     }
     fn setup_history_button<
         F: for<'a> Fn(

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -718,10 +718,13 @@ impl Window {
             .application_icon(build_config::APP_ID)
             .application_name("Geopard")
             .developer_name("ranfdev")
+            .developers(vec![
+                "ranfdev https://github.com/ranfdev",
+                "tfuxu https://github.com/tfuxu",
+            ])
             .license_type(gtk::License::Gpl30)
             .version(build_config::VERSION)
-            .developers(vec!["ranfdev"])
-            .copyright("Copyright © 2022-2023 ranfdev")
+            .copyright("Copyright © 2022-2024 ranfdev")
             .issue_url("https://github.com/ranfdev/Geopard/issues")
             .website("https://github.com/ranfdev/Geopard")
             .transient_for(self)


### PR DESCRIPTION
This is a pack of miscellaneous improvements and fixes I've made to refresh my Rust knowledge, and to remind myself how fun it is to fight the borrow checker :^)

This pack contains the following changes:
- Added `Adw.ToastOverlay` container for use in bookmark/clipboard operations
- Put Download and Input views in `Adw.Clamp` to make them width more dynamic
- Fixed a bug in `gemini` library that created malformed URLs if the site redirected to relative URL location (fixes #91)
- Fixed an mistake in `gemini` that put 10000 seconds of timeout on server response
- Removed `Pointer_*` accelerators (if they were supposed to show gestures, I can add proper accelerators later)
- Removed bottom main menu button (as in most of the app I've seen, they don't move this button to the bottom) (indirectly fixes #54)
- Made upper main menu button primary (enables `F10` shortcut)