### PR TITLE
Minor UI updates

### DIFF
--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -17,6 +17,8 @@ template $GeopardWindow: Adw.ApplicationWindow {
 
         Adw.ToastOverlay toast_overlay {
           Adw.ToolbarView toolbar_view {
+            top-bar-style: raised_border;
+            bottom-bar-style: raised_border;
             reveal-bottom-bars: false;
 
             [top]

--- a/data/resources/ui/window.blp
+++ b/data/resources/ui/window.blp
@@ -164,10 +164,9 @@ template $GeopardWindow: Adw.ApplicationWindow {
               }
 
               [end]
-              Gtk.Button {
-                icon-name: "view-grid-symbolic";
+              Adw.TabButton {
+                view: tab_view;
                 action-name: "overview.open";
-                tooltip-text: _("View Open Tabs");
               }
 
               [end]


### PR DESCRIPTION
Set top and bottom toolbar style to `raised_border` and use `Adw.TabButton` in mobile toolbar.