### PR TITLE
Switch to `libappstream`

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -26,15 +26,15 @@ if desktop_file_validate.found()
   )
 endif
 
-# Appdata
-appdata_conf = configuration_data()
-appdata_conf.set('app-id', application_id)
-appdata_conf.set('gettext-package', gettext_package)
-appdata_file = i18n.merge_file(
+# Translate and install Metainfo file
+metainfo_file = i18n.merge_file(
   input: configure_file(
     input: '@0@.metainfo.xml.in.in'.format(base_id),
     output: '@BASENAME@',
-    configuration: appdata_conf
+    configuration: configuration_data({
+      'app-id': application_id,
+      'gettext-package': gettext_package
+    })
   ),
   output: '@0@.metainfo.xml'.format(application_id),
   po_dir: podir,
@@ -42,14 +42,12 @@ appdata_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
-# Validate Appdata
-if appstream_util.found()
-  test(
-    'validate-appdata', appstream_util,
-    args: [
-      'validate', '--nonet', appdata_file.full_path()
-    ],
-    depends: appdata_file,
+# Validate Metainfo file
+appstream_cli = find_program('appstreamcli', required: false)
+if appstream_cli.found()
+  test('Validate metainfo file', appstream_cli,
+    args: ['validate', '--no-net', '--explain', metainfo_file.full_path()],
+    depends: metainfo_file
   )
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,6 @@ dependency('gtk4', version: '>= 4.0.0')
 glib_compile_resources = find_program('glib-compile-resources', required: true)
 glib_compile_schemas = find_program('glib-compile-schemas', required: true)
 desktop_file_validate = find_program('desktop-file-validate', required: false)
-appstream_util = find_program('appstream-util', required: false)
 
 cargo = find_program('cargo', required: true)
 

--- a/nix/geopard.nix
+++ b/nix/geopard.nix
@@ -16,7 +16,7 @@
 , desktop-file-utils
 , gettext
 , blueprint-compiler
-, appstream-glib
+, appstream
 , rust-analyzer
 }:
 
@@ -40,8 +40,7 @@ stdenv.mkDerivation {
     cmake
     blueprint-compiler
     desktop-file-utils
-    appstream-glib
-    blueprint-compiler
+    appstream
     cargo
     rustPlatform.cargoSetupHook
     rustc


### PR DESCRIPTION
Switch from unmaintained `appstream-util` to recommended `appstreamcli`.

> [!IMPORTANT]
> This might be a breaking change for package maintainers. A notice should be included in v1.5.0 release notes.

Resolves #101
Fixes #100