### PR TITLE
metainfo: update brand colors

### DIFF
--- a/data/com.ranfdev.Geopard.metainfo.xml.in.in
+++ b/data/com.ranfdev.Geopard.metainfo.xml.in.in
@@ -56,8 +56,8 @@
   <url type="donation">https://github.com/sponsors/ranfdev</url>
 
   <branding>
-    <color type="primary" scheme_preference="light">#fafafa</color>
-    <color type="primary" scheme_preference="dark">#222222</color>
+    <color type="primary" scheme_preference="light">#deddda</color>
+    <color type="primary" scheme_preference="dark">#5e5c64</color>
   </branding>
 
   <kudos>


### PR DESCRIPTION
Updates the brand colors to less extreme grays, since they were too close to white/black:

![image](https://github.com/ranfdev/Geopard/assets/1908896/258781e4-7dcc-421a-b4ad-6ef4b7a3e9de)
